### PR TITLE
refactor: Optimize Glucose Reading array parsing for memory efficiency

### DIFF
--- a/lib/dexcom_client/include/glucose_reading.h
+++ b/lib/dexcom_client/include/glucose_reading.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <ctime>
 #include <memory>
+#include <ArduinoJson.h>
 #include "dexcom_constants.h"
 #include "dexcom_utils.h"
 #include "i_json_value.h"
@@ -35,6 +36,14 @@ public:
      * @throws std::runtime_error if required fields are missing or invalid
      */
     explicit GlucoseReading(const IJsonValue& json);
+
+    /**
+     * @brief Constructs a GlucoseReading directly from an ArduinoJson object.
+     *
+     * @param obj The JSON object containing glucose reading data
+     * @throws std::runtime_error if required fields are missing or invalid
+     */
+    explicit GlucoseReading(ArduinoJson::JsonObjectConst obj);
 
     uint16_t getValue() const noexcept { return _value; }
     uint16_t getMgDl() const noexcept { return _value; }

--- a/lib/dexcom_client/src/glucose_reading.cpp
+++ b/lib/dexcom_client/src/glucose_reading.cpp
@@ -1,5 +1,6 @@
 #include "glucose_reading.h"
 #include <stdexcept>
+#include <ArduinoJson.h>
 
 GlucoseReading::GlucoseReading(uint16_t value, const std::string& trend, const std::string& timestamp)
     : _value(value),
@@ -34,5 +35,35 @@ GlucoseReading::GlucoseReading(const IJsonValue& json)
         _timestamp = strtoull(timestamp->c_str() + 5, nullptr, 10) / 1000; // milliseconds to seconds
     } else {
         _timestamp = 0;
+    }
+}
+
+GlucoseReading::GlucoseReading(ArduinoJson::JsonObjectConst obj)
+{
+    // Check and extract Value field
+    if (obj.containsKey("Value") && obj["Value"].is<int>()) {
+        _value = static_cast<uint16_t>(obj["Value"].as<int>());
+    } else {
+        throw std::runtime_error("Missing or invalid 'Value' field in JSON object");
+    }
+
+    // Check and extract Trend field
+    if (obj.containsKey("Trend") && obj["Trend"].is<const char*>()) {
+        const char* trendStr = obj["Trend"].as<const char*>();
+        _trend = DexcomUtils::stringToTrendDirection(trendStr);
+    } else {
+        throw std::runtime_error("Missing or invalid 'Trend' field in JSON object");
+    }
+
+    // Check and extract WT (timestamp) field
+    if (obj.containsKey("WT") && obj["WT"].is<const char*>()) {
+        const char* timestampStr = obj["WT"].as<const char*>();
+        if (timestampStr && timestampStr[0] == 'D') {
+            _timestamp = strtoull(timestampStr + 5, nullptr, 10) / 1000; // milliseconds to seconds
+        } else {
+            _timestamp = 0;
+        }
+    } else {
+        throw std::runtime_error("Missing or invalid 'WT' field in JSON object");
     }
 }

--- a/lib/glucose_parser/include/json_glucose_reading_parser.h
+++ b/lib/glucose_parser/include/json_glucose_reading_parser.h
@@ -2,6 +2,7 @@
 #define JSON_GLUCOSE_READING_PARSER_H
 
 #include "i_glucose_reading_parser.h"
+#include "i_json_parser.h"
 #include "i_json_value.h"
 #include "debug_print.h"
 #include "dexcom_errors.h"

--- a/lib/json_parser/include/arduino_json_parser.h
+++ b/lib/json_parser/include/arduino_json_parser.h
@@ -32,6 +32,8 @@ class ArduinoJsonParser : public IJsonParser {
 public:
     std::shared_ptr<IJsonValue> parseObject(const std::string& jsonString) override;
     std::vector<std::shared_ptr<IJsonValue>> parseArray(const std::string& jsonString) override;
+    bool parseJsonArray(const std::string& jsonString, 
+                       std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) override;
 
 private:
     static constexpr size_t JSON_BUFFER_SIZE = 2048;  // Adjust size as needed

--- a/lib/json_parser/include/arduino_json_parser.h
+++ b/lib/json_parser/include/arduino_json_parser.h
@@ -2,6 +2,7 @@
 #define ARDUINO_JSON_PARSER_H
 
 #include "i_json_value.h"
+#include "i_json_parser.h"
 #include <ArduinoJson.h>
 
 /**

--- a/lib/json_parser/include/arduino_json_parser.h
+++ b/lib/json_parser/include/arduino_json_parser.h
@@ -3,6 +3,7 @@
 
 #include "i_json_value.h"
 #include "i_json_parser.h"
+#include "../../dexcom_client/include/dexcom_constants.h"
 #include <ArduinoJson.h>
 
 /**
@@ -36,7 +37,9 @@ public:
                        std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) override;
 
 private:
-    static constexpr size_t JSON_BUFFER_SIZE = 2048;  // Adjust size as needed
+    // Calculate buffer size based on max readings data
+    // (MAX_MAX_COUNT * MAX_READING_JSON_SIZE) + overhead
+    static constexpr size_t JSON_BUFFER_SIZE = (DexcomConst::MAX_MAX_COUNT * DexcomConst::MAX_READING_JSON_SIZE) + 4096; // ~76KB
     using JsonDocument = StaticJsonDocument<JSON_BUFFER_SIZE>;
 };
 

--- a/lib/json_parser/include/i_dexcom_response_parser.h
+++ b/lib/json_parser/include/i_dexcom_response_parser.h
@@ -1,0 +1,40 @@
+#ifndef I_DEXCOM_RESPONSE_PARSER_H
+#define I_DEXCOM_RESPONSE_PARSER_H
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <memory>
+#include "glucose_reading.h"
+#include "dexcom_errors.h"
+
+/**
+ * @brief Interface for Dexcom JSON response parsing operations
+ */
+class IDexcomResponseParser {
+public:
+    virtual ~IDexcomResponseParser() = default;
+
+    /**
+     * @brief Parse a JSON string into a GlucoseReading object
+     * @param jsonString The JSON string to parse
+     * @return Optional GlucoseReading, empty if parsing fails
+     */
+    virtual std::optional<GlucoseReading> parseGlucoseReading(const std::string& jsonString) = 0;
+
+    /**
+     * @brief Parse a JSON string containing multiple glucose readings
+     * @param jsonString The JSON string to parse
+     * @return Vector of GlucoseReading objects
+     */
+    virtual std::vector<GlucoseReading> parseGlucoseReadings(const std::string& jsonString) = 0;
+
+    /**
+     * @brief Parse an error response from the Dexcom API
+     * @param jsonString The JSON string to parse
+     * @return Optional DexcomError, empty if no error is found
+     */
+    virtual std::unique_ptr<DexcomError> parseErrorResponse(const std::string& jsonString) = 0;
+};
+
+#endif // I_DEXCOM_RESPONSE_PARSER_H

--- a/lib/json_parser/include/i_json_parser.h
+++ b/lib/json_parser/include/i_json_parser.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <functional>
+#include <ArduinoJson.h>
 #include "i_json_value.h"
 
 /**
@@ -26,6 +28,15 @@ public:
      * @return Vector of IJsonValue objects, empty if parsing fails
      */
     virtual std::vector<std::shared_ptr<IJsonValue>> parseArray(const std::string& jsonString) = 0;
+
+    /**
+     * @brief Parse a JSON string into an array and process each element directly
+     * @param jsonString The JSON string to parse
+     * @param elementProcessor Function to process each array element
+     * @return True if parsing was successful, false otherwise
+     */
+    virtual bool parseJsonArray(const std::string& jsonString, 
+                               std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) = 0;
 };
 
 #endif // I_JSON_PARSER_H

--- a/lib/json_parser/include/i_json_parser.h
+++ b/lib/json_parser/include/i_json_parser.h
@@ -3,38 +3,29 @@
 
 #include <string>
 #include <vector>
-#include <optional>
 #include <memory>
-#include "glucose_reading.h"
-#include "dexcom_errors.h"
+#include "i_json_value.h"
 
 /**
- * @brief Interface for JSON parsing operations
+ * @brief Interface for basic JSON parsing operations
  */
 class IJsonParser {
 public:
     virtual ~IJsonParser() = default;
 
     /**
-     * @brief Parse a JSON string into a GlucoseReading object
+     * @brief Parse a JSON string into an object
      * @param jsonString The JSON string to parse
-     * @return Optional GlucoseReading, empty if parsing fails
+     * @return Shared pointer to IJsonValue, null if parsing fails
      */
-    virtual std::optional<GlucoseReading> parseGlucoseReading(const std::string& jsonString) = 0;
+    virtual std::shared_ptr<IJsonValue> parseObject(const std::string& jsonString) = 0;
 
     /**
-     * @brief Parse a JSON string containing multiple glucose readings
+     * @brief Parse a JSON string into an array
      * @param jsonString The JSON string to parse
-     * @return Vector of GlucoseReading objects
+     * @return Vector of IJsonValue objects, empty if parsing fails
      */
-    virtual std::vector<GlucoseReading> parseGlucoseReadings(const std::string& jsonString) = 0;
-
-    /**
-     * @brief Parse an error response from the Dexcom API
-     * @param jsonString The JSON string to parse
-     * @return Optional DexcomError, empty if no error is found
-     */
-    virtual std::unique_ptr<DexcomError> parseErrorResponse(const std::string& jsonString) = 0;
+    virtual std::vector<std::shared_ptr<IJsonValue>> parseArray(const std::string& jsonString) = 0;
 };
 
 #endif // I_JSON_PARSER_H

--- a/lib/json_parser/include/i_json_value.h
+++ b/lib/json_parser/include/i_json_value.h
@@ -2,8 +2,6 @@
 #define I_JSON_VALUE_H
 
 #include <string>
-#include <vector>
-#include <memory>
 #include <optional>
 
 /**
@@ -40,28 +38,6 @@ public:
      * @return Optional boolean value
      */
     virtual std::optional<bool> getBool(const std::string& key) const = 0;
-};
-
-/**
- * @brief Interface for basic JSON parsing operations
- */
-class IJsonParser {
-public:
-    virtual ~IJsonParser() = default;
-
-    /**
-     * @brief Parse a JSON string into an object
-     * @param jsonString The JSON string to parse
-     * @return Shared pointer to IJsonValue, null if parsing fails
-     */
-    virtual std::shared_ptr<IJsonValue> parseObject(const std::string& jsonString) = 0;
-
-    /**
-     * @brief Parse a JSON string into an array
-     * @param jsonString The JSON string to parse
-     * @return Vector of IJsonValue objects, empty if parsing fails
-     */
-    virtual std::vector<std::shared_ptr<IJsonValue>> parseArray(const std::string& jsonString) = 0;
 };
 
 #endif // I_JSON_VALUE_H

--- a/lib/json_parser/src/arduino_json_parser.cpp
+++ b/lib/json_parser/src/arduino_json_parser.cpp
@@ -72,3 +72,11 @@ std::vector<std::shared_ptr<IJsonValue>> ArduinoJsonParser::parseArray(const std
 
     return result;
 }
+
+bool ArduinoJsonParser::parseJsonArray(const std::string& jsonString, 
+                                     std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) {
+    // TODO: Implement efficient array parsing with callback
+    // This is a stub implementation that will be completed in a future task
+    DEBUG_PRINT("parseJsonArray called but not yet implemented");
+    return false;
+}

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 29
+
+Added JsonObjectConst constructor to GlucoseReading to avoid intermediate parsing steps, with proper type checking and error handling. All tests passing.
+
+----
+
 Task 28
 
 The project currently defines the `IJsonParser` interface incorrectly within `lib/json_parser/include/i_json_value.h`. This needs to be moved to its own header file.

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 28
+
+The project currently defines the `IJsonParser` interface incorrectly within `lib/json_parser/include/i_json_value.h`. This needs to be moved to its own header file.
+
+----
+
 Task 27
 
 Updated main.cpp to instantiate DexcomClient with both IHttpClient and IGlucoseReadingParser dependencies, correctly wiring the dependency chain and adding proper error handling.

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,19 @@
+Task 30
+
+Added the necessary includes to i_json_parser.h:
+
+Added #include <functional> to enable the use of std::function
+Added #include <ArduinoJson.h> to make JsonObjectConst available
+Added the new pure virtual method to the IJsonParser interface:
+
+virtual bool parseJsonArray(const std::string& jsonString, 
+                           std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) = 0;
+Updated the MockJsonParser class to include the new method with a proper MOCK_METHOD declaration.
+
+Added a stub implementation to ArduinoJsonParser to ensure the code compiles.
+
+----
+
 Task 29
 
 Added JsonObjectConst constructor to GlucoseReading to avoid intermediate parsing steps, with proper type checking and error handling. All tests passing.

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 32
+
+Refactored JsonGlucoseReadingParser::parse to use the more efficient parseJsonArray callback mechanism, eliminating intermediate object creation and adding a test for invalid object handling.
+
+----
+
 Task 31
 
 implemented the ArduinoJsonParser::parseJsonArray method that efficiently processes JSON arrays by applying a callback function to each object element

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 33
+
+Updated JsonGlucoseReadingParser tests to use WithArgs<1>(Invoke()) pattern for testing callback-based processing, with explicit verification of error handling and size limits.
+
+----
+
 Task 32
 
 Refactored JsonGlucoseReadingParser::parse to use the more efficient parseJsonArray callback mechanism, eliminating intermediate object creation and adding a test for invalid object handling.

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 31
+
+implemented the ArduinoJsonParser::parseJsonArray method that efficiently processes JSON arrays by applying a callback function to each object element
+
+----
+
 Task 30
 
 Added the necessary includes to i_json_parser.h:

--- a/test/test_desktop/mocks/mock_json_parser.h
+++ b/test/test_desktop/mocks/mock_json_parser.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include "i_json_parser.h"
 #include "i_json_value.h"
 
 class MockJsonParser : public IJsonParser {

--- a/test/test_desktop/mocks/mock_json_parser.h
+++ b/test/test_desktop/mocks/mock_json_parser.h
@@ -11,4 +11,5 @@ class MockJsonParser : public IJsonParser {
 public:
     MOCK_METHOD(std::shared_ptr<IJsonValue>, parseObject, (const std::string& jsonString), (override));
     MOCK_METHOD(std::vector<std::shared_ptr<IJsonValue>>, parseArray, (const std::string& jsonString), (override));
+    MOCK_METHOD(bool, parseJsonArray, (const std::string& jsonString, std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor), (override));
 };

--- a/test/test_desktop/unit/test_arduino_json_parser.cpp
+++ b/test/test_desktop/unit/test_arduino_json_parser.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include "arduino_json_parser.h"
 #include <memory>
+#include <functional>
+#include <ArduinoJson.h>
 
 class ArduinoJsonParserTest : public ::testing::Test {
 protected:
@@ -105,4 +108,98 @@ TEST_F(ArduinoJsonParserTest, ParseWrongType) {
     
     auto age = result->getInt("age");
     EXPECT_FALSE(age.has_value());
+}
+
+// New tests for parseJsonArray
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayValid) {
+    const char* json = "[{\"key\":1},{\"key\":2}]";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Expect two calls: first with {"key":1}, then with {"key":2}
+    EXPECT_CALL(mock_processor, Call(testing::_))
+        .Times(2)
+        .WillOnce(testing::DoAll(
+            testing::Invoke([](ArduinoJson::JsonObjectConst obj) {
+                EXPECT_TRUE(obj.containsKey("key"));
+                EXPECT_EQ(1, obj["key"].as<int>());
+                return true;
+            }),
+            testing::Return(true)
+        ))
+        .WillOnce(testing::DoAll(
+            testing::Invoke([](ArduinoJson::JsonObjectConst obj) {
+                EXPECT_TRUE(obj.containsKey("key"));
+                EXPECT_EQ(2, obj["key"].as<int>());
+                return true;
+            }),
+            testing::Return(true)
+        ));
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_TRUE(result);
+}
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayEmpty) {
+    const char* json = "[]";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Mock processor should not be called for empty array
+    EXPECT_CALL(mock_processor, Call(testing::_)).Times(0);
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_TRUE(result);
+}
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayInvalid) {
+    const char* json = "invalid";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Mock processor should not be called for invalid JSON
+    EXPECT_CALL(mock_processor, Call(testing::_)).Times(0);
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayNotArray) {
+    const char* json = "{\"key\":1}";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Mock processor should not be called when input is not an array
+    EXPECT_CALL(mock_processor, Call(testing::_)).Times(0);
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_FALSE(result);
+}
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayMixedTypes) {
+    const char* json = "[1, {\"key\":2}]";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Mock processor should be called once for the object element
+    EXPECT_CALL(mock_processor, Call(testing::_))
+        .WillOnce(testing::DoAll(
+            testing::Invoke([](ArduinoJson::JsonObjectConst obj) {
+                EXPECT_TRUE(obj.containsKey("key"));
+                EXPECT_EQ(2, obj["key"].as<int>());
+                return true;
+            }),
+            testing::Return(true)
+        ));
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_TRUE(result);
+}
+
+TEST_F(ArduinoJsonParserTest, ParseJsonArrayCallbackReturnsFalse) {
+    const char* json = "[{\"key\":1},{\"key\":2}]";
+    testing::MockFunction<bool(ArduinoJson::JsonObjectConst)> mock_processor;
+    
+    // Mock processor returns false on first call to stop processing
+    EXPECT_CALL(mock_processor, Call(testing::_))
+        .WillOnce(testing::Return(false));
+    
+    bool result = parser->parseJsonArray(json, mock_processor.AsStdFunction());
+    EXPECT_TRUE(result);
 }

--- a/test/test_desktop/unit/test_glucose_reading.cpp
+++ b/test/test_desktop/unit/test_glucose_reading.cpp
@@ -4,6 +4,7 @@
 #include "mock_json_value.h"
 #include <memory>
 #include <stdexcept>
+#include <ArduinoJson.h>
 
 class GlucoseReadingTest : public ::testing::Test {
 protected:
@@ -82,5 +83,79 @@ TEST_F(GlucoseReadingTest, ConstructorThrowsWhenWTFieldMissing) {
     
     EXPECT_THROW({
         GlucoseReading reading(*mockJsonValue);
+    }, std::runtime_error);
+}
+
+/**
+ * Test Case 5: Valid direct ArduinoJson constructor
+ */
+TEST_F(GlucoseReadingTest, ArduinoJsonConstructorWithValidJson) {
+    StaticJsonDocument<200> doc;
+    doc["Value"] = 120;
+    doc["Trend"] = "Flat";
+    doc["WT"] = "Date(1609459200000)";
+    
+    EXPECT_NO_THROW({
+        GlucoseReading reading(doc.as<JsonObjectConst>());
+        // Verify the reading has expected values
+        EXPECT_EQ(120, reading.getValue());
+        EXPECT_EQ(DexcomConst::TrendDirection::Flat, reading.getTrend());
+        EXPECT_EQ(1609459200, reading.getTimestamp()); // 2021-01-01 00:00:00 UTC
+    });
+}
+
+/**
+ * Test Case 6: ArduinoJson constructor with missing Value field
+ */
+TEST_F(GlucoseReadingTest, ArduinoJsonConstructorThrowsWhenValueFieldMissing) {
+    StaticJsonDocument<200> doc;
+    // Deliberately not setting Value field
+    doc["Trend"] = "Flat";
+    doc["WT"] = "Date(1609459200000)";
+    
+    EXPECT_THROW({
+        GlucoseReading reading(doc.as<JsonObjectConst>());
+    }, std::runtime_error);
+}
+
+/**
+ * Test Case 7: ArduinoJson constructor with missing Trend field
+ */
+TEST_F(GlucoseReadingTest, ArduinoJsonConstructorThrowsWhenTrendFieldMissing) {
+    StaticJsonDocument<200> doc;
+    doc["Value"] = 120;
+    // Deliberately not setting Trend field
+    doc["WT"] = "Date(1609459200000)";
+    
+    EXPECT_THROW({
+        GlucoseReading reading(doc.as<JsonObjectConst>());
+    }, std::runtime_error);
+}
+
+/**
+ * Test Case 8: ArduinoJson constructor with missing WT field
+ */
+TEST_F(GlucoseReadingTest, ArduinoJsonConstructorThrowsWhenWTFieldMissing) {
+    StaticJsonDocument<200> doc;
+    doc["Value"] = 120;
+    doc["Trend"] = "Flat";
+    // Deliberately not setting WT field
+    
+    EXPECT_THROW({
+        GlucoseReading reading(doc.as<JsonObjectConst>());
+    }, std::runtime_error);
+}
+
+/**
+ * Test Case 9: ArduinoJson constructor with incorrect type for Value
+ */
+TEST_F(GlucoseReadingTest, ArduinoJsonConstructorThrowsWhenValueHasWrongType) {
+    StaticJsonDocument<200> doc;
+    doc["Value"] = "not-a-number"; // Wrong type (string instead of int)
+    doc["Trend"] = "Flat";
+    doc["WT"] = "Date(1609459200000)";
+    
+    EXPECT_THROW({
+        GlucoseReading reading(doc.as<JsonObjectConst>());
     }, std::runtime_error);
 }

--- a/test/test_desktop/unit/test_json_glucose_reading_parser.cpp
+++ b/test/test_desktop/unit/test_json_glucose_reading_parser.cpp
@@ -4,6 +4,7 @@
 #include "../mocks/mock_json_parser.h"
 #include "../mocks/mock_json_value.h"
 #include <memory>
+#include <ArduinoJson.h>
 
 class JsonGlucoseReadingParserTest : public ::testing::Test {
 protected:
@@ -22,38 +23,50 @@ protected:
 };
 
 TEST_F(JsonGlucoseReadingParserTest, ParseEmptyArray) {
-    EXPECT_CALL(*mock_json_parser, parseArray("[]"))
-        .WillOnce(testing::Return(std::vector<std::shared_ptr<IJsonValue>>{}));
+    // Setup parseJsonArray to return true but not call the callback (empty array)
+    EXPECT_CALL(*mock_json_parser, parseJsonArray("[]", testing::_))
+        .WillOnce(testing::Return(true));
     
     auto readings = parser->parse("[]");
     EXPECT_EQ(0, readings.size());
 }
 
 TEST_F(JsonGlucoseReadingParserTest, ParseInvalidJson) {
-    EXPECT_CALL(*mock_json_parser, parseArray("invalid"))
-        .WillOnce(testing::Return(std::vector<std::shared_ptr<IJsonValue>>{}));
+    // Setup parseJsonArray to return false (failed parsing)
+    EXPECT_CALL(*mock_json_parser, parseJsonArray("invalid", testing::_))
+        .WillOnce(testing::Return(false));
     
     auto readings = parser->parse("invalid");
     EXPECT_EQ(0, readings.size());
 }
 
 TEST_F(JsonGlucoseReadingParserTest, ParseValidArray) {
-    // Create mock JSON values with expected behavior
-    auto make_valid_mock_value = []() {
-        auto val = std::make_shared<testing::NiceMock<MockJsonValue>>();
-        ON_CALL(*val, getInt("Value")).WillByDefault(testing::Return(120));
-        ON_CALL(*val, getString("Trend")).WillByDefault(testing::Return("Flat"));
-        ON_CALL(*val, getString("WT")).WillByDefault(testing::Return("Date(1609459200000)"));
-        return val;
-    };
-
-    std::vector<std::shared_ptr<IJsonValue>> mock_values;
-    mock_values.push_back(make_valid_mock_value());
-    mock_values.push_back(make_valid_mock_value());
-    
-    // Setup expectation for parseArray
-    EXPECT_CALL(*mock_json_parser, parseArray("[{},{}]"))
-        .WillOnce(testing::Return(mock_values));
+    // Use DoAnswer to call the callback with valid JSON objects
+    EXPECT_CALL(*mock_json_parser, parseJsonArray("[{},{}]", testing::_))
+        .WillOnce(testing::DoAll(
+            // First callback invocation - simulate first JSON object
+            testing::Invoke([](const std::string&, std::function<bool(ArduinoJson::JsonObjectConst)> callback) {
+                // Create a JSON document for our test
+                ArduinoJson::StaticJsonDocument<512> doc;
+                doc["Value"] = 120;
+                doc["Trend"] = "Flat";
+                doc["WT"] = "Date(1609459200000)";
+                
+                // Call the callback with our object
+                callback(doc.as<ArduinoJson::JsonObjectConst>());
+                
+                // Create a second JSON object
+                ArduinoJson::StaticJsonDocument<512> doc2;
+                doc2["Value"] = 120;
+                doc2["Trend"] = "Flat";
+                doc2["WT"] = "Date(1609459200000)";
+                
+                // Call the callback again
+                callback(doc2.as<ArduinoJson::JsonObjectConst>());
+                
+                return true;
+            })
+        ));
     
     auto readings = parser->parse("[{},{}]");
     EXPECT_EQ(2, readings.size());
@@ -67,8 +80,58 @@ TEST_F(JsonGlucoseReadingParserTest, ParseValidArray) {
     EXPECT_EQ(DexcomConst::TrendDirection::Flat, readings[1].getTrend());
 }
 
+TEST_F(JsonGlucoseReadingParserTest, ParseArrayWithInvalidObject) {
+    // Create test JSON array with mixed valid and invalid objects
+    const std::string mixedArray = "[{valid},{invalid},{valid}]";
+    
+    // Use WithArgs to capture and invoke the callback with our test data
+    EXPECT_CALL(*mock_json_parser, parseJsonArray(mixedArray, testing::_))
+        .WillOnce(testing::WithArgs<1>(testing::Invoke(
+            [](std::function<bool(ArduinoJson::JsonObjectConst)> callback) {
+                // First valid object
+                ArduinoJson::StaticJsonDocument<512> valid1;
+                valid1["Value"] = 120;
+                valid1["Trend"] = "Flat";
+                valid1["WT"] = "Date(1609459200000)";
+                
+                // Invalid object (missing required WT field)
+                ArduinoJson::StaticJsonDocument<512> invalid;
+                invalid["Value"] = 130;
+                invalid["Trend"] = "FortyFiveUp";
+                // No WT field, should cause constructor to throw
+                
+                // Second valid object
+                ArduinoJson::StaticJsonDocument<512> valid2;
+                valid2["Value"] = 140;
+                valid2["Trend"] = "SingleDown";
+                valid2["WT"] = "Date(1609459800000)";
+                
+                // Process all three objects in sequence
+                callback(valid1.as<ArduinoJson::JsonObjectConst>());
+                callback(invalid.as<ArduinoJson::JsonObjectConst>());
+                callback(valid2.as<ArduinoJson::JsonObjectConst>());
+                
+                return true;
+            }
+        )));
+    
+    // Parse the array
+    auto readings = parser->parse(mixedArray);
+    
+    // Should have only 2 readings (the valid ones)
+    EXPECT_EQ(2, readings.size());
+    
+    // Verify first reading
+    EXPECT_EQ(120, readings[0].getValue());
+    EXPECT_EQ(DexcomConst::TrendDirection::Flat, readings[0].getTrend());
+    
+    // Verify second reading (which was the third object)
+    EXPECT_EQ(140, readings[1].getValue());
+    EXPECT_EQ(DexcomConst::TrendDirection::SingleDown, readings[1].getTrend());
+}
+
 TEST_F(JsonGlucoseReadingParserTest, ParseMaxSizeArray) {
-    // Create a large array string that the mock will parse into MAX_MAX_COUNT+5 readings
+    // Create a large array string that exceeds MAX_MAX_COUNT
     std::string largeArray = "[";
     for (int i = 0; i < DexcomConst::MAX_MAX_COUNT + 5; i++) {
         if (i > 0) largeArray += ",";
@@ -76,30 +139,34 @@ TEST_F(JsonGlucoseReadingParserTest, ParseMaxSizeArray) {
     }
     largeArray += "]";
     
-    // Create a function to make mock values
-    auto make_valid_mock_value = []() {
-        auto val = std::make_shared<testing::NiceMock<MockJsonValue>>();
-        ON_CALL(*val, getInt("Value")).WillByDefault(testing::Return(120));
-        ON_CALL(*val, getString("Trend")).WillByDefault(testing::Return("Flat"));
-        ON_CALL(*val, getString("WT")).WillByDefault(testing::Return("Date(1609459200000)"));
-        return val;
-    };
-    
-    // Create exactly MAX_MAX_COUNT + 5 mock values to return
-    const int totalMockValues = DexcomConst::MAX_MAX_COUNT + 5;
-    std::vector<std::shared_ptr<IJsonValue>> mockValues;
-    mockValues.reserve(totalMockValues);  // Optimize space allocation
-    
-    for (int i = 0; i < totalMockValues; i++) {
-        mockValues.push_back(make_valid_mock_value());
-    }
-    
-    // Verify we actually created the expected number of mock values
-    ASSERT_EQ(totalMockValues, mockValues.size());
-    
-    // Setup expectation for parseArray
-    EXPECT_CALL(*mock_json_parser, parseArray(largeArray))
-        .WillOnce(testing::Return(mockValues));
+    // Test that the processing stops after MAX_MAX_COUNT elements
+    EXPECT_CALL(*mock_json_parser, parseJsonArray(largeArray, testing::_))
+        .WillOnce(testing::DoAll(
+            testing::Invoke([](const std::string&, std::function<bool(ArduinoJson::JsonObjectConst)> callback) {
+                // Create a JSON object template
+                ArduinoJson::StaticJsonDocument<512> doc;
+                doc["Value"] = 120;
+                doc["Trend"] = "Flat";
+                doc["WT"] = "Date(1609459200000)";
+                auto jsonObj = doc.as<ArduinoJson::JsonObjectConst>();
+                
+                // Call the callback MAX_MAX_COUNT + 5 times
+                // The callback should return false after MAX_MAX_COUNT calls
+                bool continueProcessing = true;
+                int callCount = 0;
+                
+                while (continueProcessing && callCount < DexcomConst::MAX_MAX_COUNT + 5) {
+                    continueProcessing = callback(jsonObj);
+                    callCount++;
+                }
+                
+                // The callback should have stopped processing after MAX_MAX_COUNT elements
+                EXPECT_EQ(DexcomConst::MAX_MAX_COUNT + 1, callCount);
+                EXPECT_FALSE(continueProcessing);
+                
+                return true;
+            })
+        ));
 
     auto readings = parser->parse(largeArray);
     


### PR DESCRIPTION
### Problem

The previous implementation of parsing JSON arrays (specifically for glucose readings) involved creating and copying `StaticJsonDocument` objects for each element in the array. This resulted in excessive memory allocation (potentially >70KB for max readings) on the heap/stack, making it unsuitable for the memory-constrained ESP32 environment.

### Solution

This PR refactors the JSON parsing mechanism for arrays to significantly improve memory efficiency:

- Introduced `IJsonParser::parseJsonArray` interface method using a callback (`std::function<bool(ArduinoJson::JsonObjectConst)>`) to process elements in place.
- Implemented `ArduinoJsonParser::parseJsonArray` to parse the entire JSON string into a *single* `JsonDocument` and iterate through elements, invoking the callback without intermediate allocations per element.
- Added a direct `GlucoseReading(ArduinoJson::JsonObjectConst)` constructor to build readings efficiently from parsed objects.
- Refactored `JsonGlucoseReadingParser::parse` to utilize the new `parseJsonArray` method and the direct `GlucoseReading` constructor.
- Removed the usage of the intermediate `IJsonValue` layer for array elements, simplifying the flow.
- Increased the `JSON_BUFFER_SIZE` in `ArduinoJsonParser` to accommodate the largest expected glucose reading response (~78KB).
- Updated all relevant unit tests (`test_glucose_reading`, `test_arduino_json_parser`, `test_json_glucose_reading_parser`) to reflect the new approach and ensure correctness.
- Minor cleanup: Moved `IJsonParser` interface to its dedicated header file (`i_json_parser.h`).

### Impact

- **Reduced Memory Usage:** Significantly lowers peak memory consumption during the parsing of glucose reading arrays.
- **Improved Performance:** Reduces overhead associated with copying JSON data.
- **Maintained Test Coverage:** All unit tests pass, verifying the new implementation.