### PR TITLE
Remove unused static JSON buffer definitions from ArduinoJsonParser header

### DIFF
--- a/lib/json_parser/include/arduino_json_parser.h
+++ b/lib/json_parser/include/arduino_json_parser.h
@@ -14,10 +14,6 @@ public:
                        std::function<bool(ArduinoJson::JsonObjectConst)> elementProcessor) override;
 
 private:
-    // Calculate buffer size based on max readings data
-    // (MAX_MAX_COUNT * MAX_READING_JSON_SIZE) + overhead
-    static constexpr size_t JSON_BUFFER_SIZE = (DexcomConst::MAX_MAX_COUNT * DexcomConst::MAX_READING_JSON_SIZE) + 4096; // ~76KB
-    using JsonDocument = StaticJsonDocument<JSON_BUFFER_SIZE>;
 };
 
 #endif // ARDUINO_JSON_PARSER_H

--- a/task_history.md
+++ b/task_history.md
@@ -1,3 +1,9 @@
+Task 41
+
+Removed unused static buffer size constant and JsonDocument type alias from ArduinoJsonParser header.
+
+----
+
 Task 40
 
 Successfully cleaned up unnecessary #include directives from multiple files after the removal of IJsonValue, ArduinoJsonValue, and related functionality. Specifically:


### PR DESCRIPTION
Removes the `JSON_BUFFER_SIZE` constant and the `JsonDocument` type alias (which defined a large `StaticJsonDocument`) from `lib/json_parser/include/arduino_json_parser.h`.

These definitions became unused and misleading after the implementation switched to using `DynamicJsonDocument` in `arduino_json_parser.cpp`. This change cleans up the header file and eliminates potential confusion without affecting functionality.